### PR TITLE
Enum fix RFC compliance

### DIFF
--- a/xdrc/gen_hh.cc
+++ b/xdrc/gen_hh.cc
@@ -292,8 +292,8 @@ gen(std::ostream &os, const rpc_enum &e)
     << "      return nullptr;" << endl
     << "    }" << endl
     << "  }" << endl
-    << "  static const std::vector<uint32_t> &enum_values() {" << endl
-    << "    static const std::vector<uint32_t> _xdr_enum_vec = {";
+    << "  static const std::vector<int32_t> &enum_values() {" << endl
+    << "    static const std::vector<int32_t> _xdr_enum_vec = {";
   bool first = true;
   for (const rpc_const &c : e.tags) {
     if (first)
@@ -319,7 +319,7 @@ pswitch(const rpc_union &u, string id = string())
     id = u.tagid + '_';
   string ret = "switch (";
   if (u.tagtype == "bool")
-    ret += "std::uint32_t{" + id + "}";
+    ret += "std::int32_t{" + id + "}";
   else
     ret += id;
   ret += ") {";
@@ -385,7 +385,7 @@ gen(std::ostream &os, const rpc_union &u)
   if (blank)
     os << endl;
   os << nl.outdent << "private:"
-     << nl << "std::uint32_t " << u.tagid << "_;"
+     << nl << "std::int32_t " << u.tagid << "_;"
      << nl << "union {";
   ++nl;
   for (const rpc_ufield &f : u.fields)
@@ -399,7 +399,7 @@ gen(std::ostream &os, const rpc_union &u)
 
   // _xdr_field_number
   os << nl
-     << "static Constexpr int _xdr_field_number(std::uint32_t which) {";
+     << "static Constexpr int _xdr_field_number(std::int32_t which) {";
   union_function(os, u, "which", [](const rpc_ufield *uf) {
       using std::to_string;
       if (uf)
@@ -428,7 +428,7 @@ gen(std::ostream &os, const rpc_union &u)
       << nl << "_xdr_with_mem_ptr(_F &";
   if (usesVars)
       os << "_f";
-  os << ", std::uint32_t which, A&&...";
+  os << ", std::int32_t which, A&&...";
   if (usesVars)
     os << "a";
   os << ") {";
@@ -442,9 +442,9 @@ gen(std::ostream &os, const rpc_union &u)
 
   // _xdr_discriminant
   //os << nl << "using _xdr_discriminant_t = " << u.tagtype << ";";
-  os << nl << "std::uint32_t _xdr_discriminant() const { return "
+  os << nl << "std::int32_t _xdr_discriminant() const { return "
      << u.tagid << "_; }";
-  os << nl << "void _xdr_discriminant(std::uint32_t which,"
+  os << nl << "void _xdr_discriminant(std::int32_t which,"
      << " bool validate = true) {"
      << nl.open << "int fnum = _xdr_field_number(which);"
      << nl << "if (fnum < 0 && validate)"
@@ -494,7 +494,7 @@ gen(std::ostream &os, const rpc_union &u)
      << u.tagid << "_, *this, source);"
      << nl << "else {"
      << nl.open << "this->~" << u.id << "();"
-     << nl << u.tagid << "_ = std::uint32_t(-1);" // might help with exceptions
+     << nl << u.tagid << "_ = std::int32_t(-1);" // might help with exceptions
      << nl << "_xdr_with_mem_ptr(xdr::field_constructor, "
      << "source." << u.tagid << "_, *this, source);"
      << nl.close << "}"
@@ -509,7 +509,7 @@ gen(std::ostream &os, const rpc_union &u)
      << nl << "                    std::move(source));"
      << nl << "else {"
      << nl.open << "this->~" << u.id << "();"
-     << nl << u.tagid << "_ = std::uint32_t(-1);" // might help with exceptions
+     << nl << u.tagid << "_ = std::int32_t(-1);" // might help with exceptions
      << nl << "_xdr_with_mem_ptr(xdr::field_constructor, "
      << "source." << u.tagid << "_, *this,"
      << nl << "                  std::move(source));"
@@ -556,7 +556,7 @@ gen(std::ostream &os, const rpc_union &u)
     << u.tagid << "());" << endl << endl;
 
   top_material
-    << "  static const char *union_field_name(std::uint32_t which) {" << endl
+    << "  static const char *union_field_name(std::int32_t which) {" << endl
     << "    switch (union_type::_xdr_field_number(which)) {" << endl;
   for (const rpc_ufield &uf : u.fields) {
     if (uf.fieldno <= 0)
@@ -573,7 +573,7 @@ gen(std::ostream &os, const rpc_union &u)
 
 #if 0
   top_material
-    << "  static Constexpr const char *union_field_name(std::uint32_t which) {";
+    << "  static Constexpr const char *union_field_name(std::int32_t which) {";
   if (!namespaces.empty())
     top_material
       << endl << "    using namespace " << cur_ns() << ";";
@@ -599,11 +599,11 @@ gen(std::ostream &os, const rpc_union &u)
     << "  }" << endl << endl;
 
 #if 0
-    << "  static std::uint32_t union_discriminant(const union_type &u) {"
+    << "  static std::int32_t union_discriminant(const union_type &u) {"
     << endl
     << "    return u." << u.tagid << "_;" << endl
     << "  }" << endl
-    << "  static void union_discriminant(union_type &u, std::uint32_t d,"
+    << "  static void union_discriminant(union_type &u, std::int32_t d,"
     << endl
     << "                                 bool validate = true) {" << endl
     << "    int fnum = union_type::_xdr_field_number(d);" << endl

--- a/xdrpp/types.h
+++ b/xdrpp/types.h
@@ -244,8 +244,8 @@ template<> struct xdr_traits<bool>
   static Constexpr const char *enum_name(uint32_t b) {
     return b == 0 ? "FALSE" : b == 1 ? "TRUE" : nullptr;
   }
-  static const std::vector<uint32_t> &enum_values() {
-    static const std::vector<uint32_t> v = { false, true };
+  static const std::vector<int32_t> &enum_values() {
+    static const std::vector<int32_t> v = { 0, 1 };
     return v;
   }
 };

--- a/xdrpp/types.h
+++ b/xdrpp/types.h
@@ -39,26 +39,41 @@ size32(std::size_t s)
 //! Generic class of XDR unmarshaling errors.
 struct xdr_runtime_error : std::runtime_error {
   using std::runtime_error::runtime_error;
+  explicit xdr_runtime_error(const char *m) : runtime_error(m)
+  {
+  }
 };
 
 //! Attempt to exceed the bounds of a variable-length array or string.
 struct xdr_overflow : xdr_runtime_error {
   using xdr_runtime_error::xdr_runtime_error;
+  explicit xdr_overflow(const char *m) : xdr_runtime_error(m)
+  {
+  }
 };
 
 //! Message not multiple of 4 bytes, or cannot fully be parsed.
 struct xdr_bad_message_size : xdr_runtime_error {
   using xdr_runtime_error::xdr_runtime_error;
+  explicit xdr_bad_message_size(const char *m) : xdr_runtime_error(m)
+  {
+  }
 };
 
 //! Attempt to set invalid value for a union discriminant.
 struct xdr_bad_discriminant : xdr_runtime_error {
   using xdr_runtime_error::xdr_runtime_error;
+  explicit xdr_bad_discriminant(const char *m) : xdr_runtime_error(m)
+  {
+  }
 };
 
 //! Padding bytes that should have contained zero don't.
 struct xdr_should_be_zero : xdr_runtime_error {
   using xdr_runtime_error::xdr_runtime_error;
+  explicit xdr_should_be_zero(const char *m) : xdr_runtime_error(m)
+  {
+  }
 };
 
 //! Attempt to access wrong field of a union.  Note that this is not
@@ -68,6 +83,9 @@ struct xdr_should_be_zero : xdr_runtime_error {
 //! before accessing the wrong field.
 struct xdr_wrong_union : std::logic_error {
   using std::logic_error::logic_error;
+  explicit xdr_wrong_union(const char *m) : logic_error(m)
+  {
+  }
 };
 
 


### PR DESCRIPTION
Finished up proper support for enums in XDR (previous commit broke enums): enums are now int32 instead of uint32 per RFC.

Also avoid generating code that triggers warnings (unused parameters):
old code was generating things like

``` C++
  template<typename _F, typename...A> static bool
  _xdr_with_mem_ptr(_F & f, std::int32_t which, A&& a...) {
...
```

now it generates

``` C++
  template<typename _F, typename...A> static bool
  _xdr_with_mem_ptr(_F &, std::int32_t which, A&&...) {
...
```
