### PR TITLE
Work around static destructor fiasco in debug mode.

### DIFF
--- a/xdrc/xdrc.cc
+++ b/xdrc/xdrc.cc
@@ -202,6 +202,13 @@ main(int argc, char **argv)
   yyparse ();
   checkliterals ();
 
+  // Subtle but necessary: the 'ids' static above needs to be cleared by
+  // shutdown to ensure its dtor doesn't try taking an uninitialized mutex while
+  // freeing the set nodes and/or strings. When building xdrc against libc++
+  // with -D_LIBCPP_DEBUG=1 on versions before 9.0.1 (specifically before
+  // https://bugs.llvm.org/show_bug.cgi?id=27658) this caused a shutdown crash.
+  ids.clear();
+
   if (pclose(yyin))
     exit(1);
 


### PR DESCRIPTION
Comment explains it, but for posterity:

Running a C++ program that contains a static `std::set<std::string>` that is nonempty at program termination, on clang++ before 9.0.1 (specifically before https://bugs.llvm.org/show_bug.cgi?id=27658 landed), with `-D_LIBCPP_DEBUG=1`, will crash on exit. The following example will exhibit the bug:

~~~
$ cat t.cc
#include <set>
#include <string>
std::set<std::string> tmp;
int main()
{
    tmp.insert("hello");
}
$ clang++ -stdlib=libc++ -D_LIBCPP_DEBUG=1 t.cc
$ ./a.out 
terminating with unexpected exception of type std::__1::system_error: mutex lock failed: Invalid argument
Aborted (core dumped)
~~~

I believe this has to do with the set's destructor trying to take a deinitialized mutex held by the global node-iterator-tracking machinery used by `_LIBCPP_DEBUG=1` but I haven't tracked down the exact mutex. In any case I _did_ bisect LLVM down to the patch above and have confirmed that simply clearing the static fixes the crash (no set-nodes to free by shutdown) so aside from the verbosity of the comment explaining it I think this is probably the cleanest fix.