### PR TITLE
Cereal fixes

### DIFF
--- a/tests/cereal.cc
+++ b/tests/cereal.cc
@@ -45,5 +45,18 @@ main()
 
   cout << xdr::xdr_to_string(n2);
 
+  testns::nested_cereal_adapter_calls nc;
+  nc.strptr.activate() = "hello";
+  nc.strvec.push_back("goodbye");
+  nc.strarr[0] = "friends";
+  {
+    ostringstream obuf2;
+    {
+      cereal::JSONOutputArchive archive(obuf2);
+      archive(nc);
+    }
+    cout << obuf2.str();
+  }
+
   return 0;
 }

--- a/tests/xdrtest.x
+++ b/tests/xdrtest.x
@@ -163,4 +163,11 @@ union voidu switch (bool b) {
     void;
 };
 
+typedef string string32<32>;
+struct nested_cereal_adapter_calls {
+  string32* strptr;
+  string32  strvec<>;
+  string32  strarr[2];
+};
+
 }

--- a/xdrpp/cereal.h
+++ b/xdrpp/cereal.h
@@ -57,7 +57,7 @@ std::enable_if<cereal::traits::is_output_serializable<
                && xdr_traits<T>::is_bytes>::type
 save(Archive &ar, const T &t)
 {
-  if (xdr_traits<T>::variable_length)
+  if (xdr_traits<T>::variable_nelem)
     ar(cereal::make_size_tag(static_cast<cereal::size_type>(t.size())));
   ar(cereal::binary_data(const_cast<char *>(
          reinterpret_cast<const char *>(t.data())), t.size()));
@@ -70,7 +70,7 @@ std::enable_if<cereal::traits::is_input_serializable<
 load(Archive &ar, T &t)
 {
   cereal::size_type size;
-  if (xdr_traits<T>::variable_length)
+  if (xdr_traits<T>::variable_nelem)
     ar(cereal::make_size_tag(size));
   else
     size = t.size();


### PR DESCRIPTION
There are maybe .. four fixes here? Only the last is blocking / necessary, and I think the fix for it is probably wrong -- insight into why it's happening / better bugfix welcome!

  - First is just a typo -- `variable_length` => `variable_nelem`
  - Second is that the `nvp_adapter::apply` methods on `xstring` were passing their arguments in the wrong order: (field, string) rather than (string, field)
  - Third is that those methods also called `apply` on their inner values rather than `xdr::archive` to allow catching `archive` overloads.
  - Fourth is a kludgy "fix" to the way we write container types / composite types in xdrpp that have an `xdr::xstring` inside them. For possibly magic C++ override / static dispatch reasons I don't understand, cereal winds up passing an un-translated `xstring` through to the archive backend and JSONOutputArchive winds up writing a string _and_ an object. So in the `xdr::xvector<xdr::xstring>` case we wind up writing something like `["hello", {}]` when writing a vector containing one string; and in the `xdr::pointer<xdr::xstring>` and `xdr::xarray<xdr::xstring>` cases, RapidJSON correctly notes that it's forming a structurally invalid "key-value pair" like `{"value1": "hello", {}}` and simply crashes.

Minimal testcase included, ought to be enough to figure out a more-real fix.