### PR TITLE
Cereal override

### DIFF
--- a/tests/cereal.cc
+++ b/tests/cereal.cc
@@ -2,11 +2,20 @@
 #include <cassert>
 #include <iostream>
 #include <sstream>
-#include <xdrpp/cereal.h>
 #include <xdrpp/printer.h>
 #include <cereal/archives/binary.hpp>
 #include <cereal/archives/json.hpp>
 #include "tests/xdrtest.hh"
+
+void
+cereal_override(cereal::JSONOutputArchive &ar,
+                const testns::inner &t,
+                const char* field)
+{
+    xdr::archive(ar, 9999, "bort");
+}
+
+#include <xdrpp/cereal.h>
 
 using namespace std;
 
@@ -56,6 +65,17 @@ main()
       archive(nc);
     }
     cout << obuf2.str();
+  }
+
+  {
+    testns::outer tu;
+    ostringstream obuf2;
+    {
+      cereal::JSONOutputArchive archive(obuf2);
+      archive(tu);
+    }
+    cout << obuf2.str();
+    assert(obuf2.str().find("\"bort\": 9999") != string::npos);
   }
 
   return 0;

--- a/tests/xdrtest.x
+++ b/tests/xdrtest.x
@@ -170,4 +170,11 @@ struct nested_cereal_adapter_calls {
   string32  strarr[2];
 };
 
+struct inner {
+  int f;
+};
+struct outer {
+  inner in;
+};
+
 }

--- a/xdrpp/cereal.h
+++ b/xdrpp/cereal.h
@@ -141,7 +141,7 @@ template<typename Archive> struct nvp_adapter {
   template<typename T> static
   std::enable_if_t<has_cereal_override<Archive, T>::value>
   apply(Archive &ar, T &&t, const char *field) {
-    cereal_override(ar, t, field);
+    cereal_override(ar, std::forward<T>(t), field);
   }
 };
 } // namespace detail

--- a/xdrpp/cereal.h
+++ b/xdrpp/cereal.h
@@ -113,12 +113,12 @@ load(Archive &ar, T &t)
 
 // value is true iff there exists a function
 //
-// cereal_override(Archive, T, const char *)
+// cereal_override(Archive&, T, const char *)
 //
 // or at least callable with such arguments.
 template<typename Archive, typename T> class has_cereal_override {
   template<typename U> static std::true_type
-  test(decltype(cereal_override(std::declval<Archive>(),
+  test(decltype(cereal_override(std::declval<Archive&>(),
 				std::declval<U>(),
 				"")) *);
 

--- a/xdrpp/cereal.h
+++ b/xdrpp/cereal.h
@@ -32,7 +32,7 @@ class JSONInputArchive;
 class JSONOutputArchive;
 class XMLOutputArchive;
 class XMLInputArchive;
-}
+} // namespace cereal
 
 namespace xdr {
 
@@ -111,17 +111,40 @@ load(Archive &ar, T &t)
   ar(cereal::binary_data(t.data(), size));
 }
 
+// value is true iff there exists a function
+//
+// cereal_override(Archive, T, const char *)
+//
+// or at least callable with such arguments.
+template<typename Archive, typename T> class has_cereal_override {
+  template<typename U> static std::true_type
+  test(decltype(cereal_override(std::declval<Archive>(),
+				std::declval<U>(),
+				"")) *);
+
+  template<typename U> static std::false_type test(...);
+
+public:
+  static constexpr bool value = decltype(test<T>(0))::value;
+};
 
 template<typename Archive> struct nvp_adapter {
-  template<typename T> static void
+  template<typename T> static
+  std::enable_if_t<!has_cereal_override<Archive, T>::value>
   apply(Archive &ar, T &&t, const char *field) {
     if (field)
       ar(cereal::make_nvp(field, std::forward<T>(t)));
     else
       ar(std::forward<T>(t));
   }
+
+  template<typename T> static
+  std::enable_if_t<has_cereal_override<Archive, T>::value>
+  apply(Archive &ar, T &&t, const char *field) {
+    cereal_override(ar, t, field);
+  }
 };
-}
+} // namespace detail
 
 //! \hideinitializer \cond
 #define CEREAL_ARCHIVE_TAKES_NAME(archive)		\
@@ -135,11 +158,11 @@ CEREAL_ARCHIVE_TAKES_NAME(XMLInputArchive);
 //! \endcond
 
 
-}
+} // namespace xdr
 
 namespace cereal {
 using xdr::detail::load;
 using xdr::detail::save;
-}
+} // namespace cereal
 
 #endif // !_XDRPP_CEREAL_H_HEADER_INCLUDED_


### PR DESCRIPTION
This picks up from David's cereal-override branch with a small (but quite obscure!) fix to use `std::declval<Archive&>` in the `has_cereal_override` probe. This is necessary because the signatures of `nvp_adapter::apply` and `xdr::archive` take their `Archive` parameter by non-const, non-rval reference (`Archive&`), and `std::declval<Archive>` alone resolves to an `Archive&&` which won't bind to `Archive&`. But if we call `std::declval<Archive&>` it's defined to return an `Archive&`.

(A lot of stackoverflow, C++ standard scrutiny and trial and error discovered this -- I would never have figured it out alone!)