### PR TITLE
temporarily disable standard layout requirement on message_t

### DIFF
--- a/xdrpp/message.h
+++ b/xdrpp/message.h
@@ -63,9 +63,6 @@ public:
   static msg_ptr alloc(std::size_t size);
 };
 
-static_assert(std::is_standard_layout<message_t>::value,
-	      "message_t should be standard layout");
-
 }
 
 #endif // !_XDRPP_MESSAGE_H_HEADER_INCLUDED_


### PR DESCRIPTION
on some systems std::unique_ptr<sockaddr> does not seem to meet such requirement