### PR TITLE
g++ 11 : offsetof expects the "member offset" to be constant

### DIFF
--- a/xdrpp/marshal.cc
+++ b/xdrpp/marshal.cc
@@ -21,7 +21,7 @@ message_t::alloc(std::size_t size)
   // continuation fragments, and instead always set the last-record
   // bit to produce a single-fragment record.
   assert(size < 0x80000000);
-  void *raw = std::malloc(offsetof(message_t, buf_[size + 4]));
+  void *raw = std::malloc(offsetof(message_t, buf_) + size + 4);
   if (!raw)
     throw std::bad_alloc();
   message_t *m = new (raw) message_t (size);


### PR DESCRIPTION
I ran into this on g++ 11.1.0 installed on Arch Linux.

The wording in https://en.cppreference.com/w/cpp/types/offsetof is pretty vague.

`offsetof(message_t, buf_[size + 4])` does not compile anymore because `offsetof` expects the second argument to be a constant (which is not the case in this code).
