### PR TITLE
Add -fno-exceptions support to marshaling/types in xdrpp

### DIFF
--- a/xdrc/union.h
+++ b/xdrc/union.h
@@ -91,8 +91,12 @@ public:
   //! constructor.
   union_entry_base &operator=(const union_entry_base &ueb) {
     destroy();
-    try { ueb.copy_construct_to(this); }
-    catch(...) { new (static_cast<void *>(this)) union_entry_base; }
+    #if __cpp_exceptions
+      try { ueb.copy_construct_to(this); }
+      catch(...) { new (static_cast<void *>(this)) union_entry_base; }
+    #else
+      ueb.copy_construct_to(this);
+    #endif
     return *this;
   }
 #endif // UNION_COPY_CONSTRUCT
@@ -100,8 +104,12 @@ public:
   //! constructor.
   union_entry_base &operator=(union_entry_base &&ueb) {
     destroy();
-    try { ueb.move_construct_to(this); }
-    catch(...) { new (static_cast<void *>(this)) union_entry_base; }
+    #if __cpp_exceptions
+      try { ueb.move_construct_to(this); }
+      catch(...) { new (static_cast<void *>(this)) union_entry_base; }
+    #else
+      ueb.move_construct_to(this);
+    #endif
     return *this;
   }
   //! Never call this destructor.\ Call union_entry_base::destroy()
@@ -178,9 +186,13 @@ public:
   //! union_entry::get subsequently work.
   T &select() {
     if (!constructed()) {
-      destroy(); 
-      try { new (static_cast<void *>(this)) union_entry; }
-      catch(...) { new (static_cast<void *>(this)) union_entry_base; throw; }
+      destroy();
+      #if __cpp_exceptions
+        try { new (static_cast<void *>(this)) union_entry; }
+        catch(...) { new (static_cast<void *>(this)) union_entry_base; throw; }
+      #else
+        new (static_cast<void *>(this)) union_entry;
+      #endif
     }
     return val_;
   }
@@ -188,8 +200,12 @@ public:
   //! using the supplied constructor arguments.
   template<typename ...A> void emplace(A&&...a) {
     destroy();
-    try { new (static_cast<void *>(this)) union_entry{std::forward<A>(a)...}; }
-    catch(...) { new (static_cast<void *>(this)) union_entry_base; throw; }
+    #if __cpp_exceptions
+      try { new (static_cast<void *>(this)) union_entry{std::forward<A>(a)...}; }
+      catch(...) { new (static_cast<void *>(this)) union_entry_base; throw; }
+    #else
+      new (static_cast<void *>(this)) union_entry{std::forward<A>(a)...};
+    #endif
   }
   //! Select \c T (if necessary) and assign to it.  Uses <tt>T</tt>'s
   //! copy or move constructor if \c T is not already selected,

--- a/xdrpp/exception.h
+++ b/xdrpp/exception.h
@@ -50,6 +50,22 @@ struct rpc_call_stat {
   }
 };
 
+#if __cpp_exceptions
+#define THROW_MACRO(expname) \
+  template<typename... T> \
+  void throw_##expname (T... what) \
+  { \
+    throw expname (what...); \
+  }
+#else
+ #define THROW_MACRO(expname) \
+  template<typename... T> \
+  void throw_##expname (T... what) \
+  { \
+    std::abort(); \
+  }
+#endif
+
 //! This is the exception raised in an RPC client when it reaches the
 //! server and transmits a call, with no connection or communication
 //! errors, but the server replies with an RPC-level message header
@@ -69,6 +85,14 @@ struct xdr_system_error : xdr_runtime_error {
   xdr_system_error(const char *what, int no = errno)
     : xdr_runtime_error(std::string(what) + ": " + xdr_strerror(no)) {}
 };
+
+THROW_MACRO(xdr_call_error);
+THROW_MACRO(xdr_system_error);
+
+#undef THROW_MACRO
+
+
+
 
 }
 

--- a/xdrpp/marshal.cc
+++ b/xdrpp/marshal.cc
@@ -23,7 +23,7 @@ message_t::alloc(std::size_t size)
   assert(size < 0x80000000);
   void *raw = std::malloc(sizeof(message_t) + size);
   if (!raw)
-    throw std::bad_alloc();
+    throw_std::bad_alloc();
   message_t *m = new (raw) message_t (size);
   *reinterpret_cast<std::uint32_t *>(m->raw_data()) =
     swap32le(size32(size) | 0x80000000);
@@ -34,7 +34,7 @@ void
 message_t::shrink(std::size_t newsize)
 {
   if (newsize > size_)
-    throw std::out_of_range("message_t::shrink new size bigger than old");
+    throw_std::out_of_range("message_t::shrink new size bigger than old");
   size_ = newsize;
   *reinterpret_cast<std::uint32_t *>(raw_data()) =
     swap32le(size32(newsize) | 0x80000000);
@@ -51,7 +51,7 @@ marshal_base::get_bytes(const std::uint32_t *&pr, void *buf, std::size_t len)
   while (len & 3) {
     ++len;
     if (*p++ != '\0')
-      throw xdr_should_be_zero("Non-zero padding bytes encountered");
+      throw_xdr_should_be_zero("Non-zero padding bytes encountered");
   }
   pr = reinterpret_cast<const std::uint32_t *>(p);
 }

--- a/xdrpp/marshal.cc
+++ b/xdrpp/marshal.cc
@@ -23,7 +23,7 @@ message_t::alloc(std::size_t size)
   assert(size < 0x80000000);
   void *raw = std::malloc(sizeof(message_t) + size);
   if (!raw)
-    throw_std::bad_alloc();
+    throw_xdr_bad_alloc();
   message_t *m = new (raw) message_t (size);
   *reinterpret_cast<std::uint32_t *>(m->raw_data()) =
     swap32le(size32(size) | 0x80000000);
@@ -34,7 +34,7 @@ void
 message_t::shrink(std::size_t newsize)
 {
   if (newsize > size_)
-    throw_std::out_of_range("message_t::shrink new size bigger than old");
+    throw_xdr_out_of_range("message_t::shrink new size bigger than old");
   size_ = newsize;
   *reinterpret_cast<std::uint32_t *>(raw_data()) =
     swap32le(size32(newsize) | 0x80000000);

--- a/xdrpp/marshal.cc
+++ b/xdrpp/marshal.cc
@@ -23,7 +23,7 @@ message_t::alloc(std::size_t size)
   assert(size < 0x80000000);
   void *raw = std::malloc(sizeof(message_t) + size);
   if (!raw)
-    throw_xdr_bad_alloc();
+    throw_std_bad_alloc();
   message_t *m = new (raw) message_t (size);
   *reinterpret_cast<std::uint32_t *>(m->raw_data()) =
     swap32le(size32(size) | 0x80000000);
@@ -34,7 +34,7 @@ void
 message_t::shrink(std::size_t newsize)
 {
   if (newsize > size_)
-    throw_xdr_out_of_range("message_t::shrink new size bigger than old");
+    throw_std_out_of_range("message_t::shrink new size bigger than old");
   size_ = newsize;
   *reinterpret_cast<std::uint32_t *>(raw_data()) =
     swap32le(size32(newsize) | 0x80000000);

--- a/xdrpp/marshal.cc
+++ b/xdrpp/marshal.cc
@@ -22,8 +22,13 @@ message_t::alloc(std::size_t size)
   // bit to produce a single-fragment record.
   assert(size < 0x80000000);
   void *raw = std::malloc(sizeof(message_t) + size);
-  if (!raw)
-    throw_std_bad_alloc();
+  if (!raw) {
+    #if __cpp_exceptions
+      throw_std_bad_alloc();
+    #else
+      return nullptr;
+    #endif
+  }
   message_t *m = new (raw) message_t (size);
   *reinterpret_cast<std::uint32_t *>(m->raw_data()) =
     swap32le(size32(size) | 0x80000000);

--- a/xdrpp/marshal.h
+++ b/xdrpp/marshal.h
@@ -104,7 +104,7 @@ template<typename Base> struct xdr_generic_put : Base {
   void check(size_t n) const {
     if (n > size_t(reinterpret_cast<char *>(e_)
 		   - reinterpret_cast<char *>(p_)))
-      throw xdr_overflow("insufficient buffer space in xdr_generic_put");
+      throw_xdr_overflow("insufficient buffer space in xdr_generic_put");
   }
 
   template<xdr_numlike T>
@@ -135,7 +135,7 @@ template<typename Base> struct xdr_generic_put : Base {
   template<xdr_type T> requires xdr_class<T> || xdr_container<T>
   void operator()(const T &t) {
     if (!marshal_base::stack_limit--)
-      throw xdr_stack_overflow("stack overflow in xdr_generic_put");
+      throw_xdr_stack_overflow("stack overflow in xdr_generic_put");
     xdr_traits<T>::save(*this, t);
     ++marshal_base::stack_limit;
   }
@@ -161,7 +161,7 @@ template<typename Base> struct xdr_generic_get : Base {
     // Message could be coming from untrusted source, so bad length is
     // not an assertion failure.
     if (reinterpret_cast<intptr_t>(end) & 3)
-      throw xdr_bad_message_size("xdr_generic_get: message size not"
+      throw_xdr_bad_message_size("xdr_generic_get: message size not"
                                  " multiple of 4");
     assert(p_ <= e_);
   }
@@ -171,7 +171,7 @@ template<typename Base> struct xdr_generic_get : Base {
   void check(size_t n) const {
     if (n > size_t(reinterpret_cast<const char *>(e_)
 		   - reinterpret_cast<const char *>(p_)))
-      throw xdr_overflow("insufficient buffer space in xdr_generic_get");
+      throw_xdr_overflow("insufficient buffer space in xdr_generic_get");
   }
 
   template<xdr_numlike T>
@@ -204,14 +204,14 @@ template<typename Base> struct xdr_generic_get : Base {
   template<xdr_type T> requires xdr_class<T> || xdr_container<T>
   void operator()(T &t) {
     if (!marshal_base::stack_limit--)
-      throw xdr_stack_overflow("stack overflow in xdr_generic_get");
+      throw_xdr_stack_overflow("stack overflow in xdr_generic_get");
     xdr_traits<T>::load(*this, t);
     ++marshal_base::stack_limit;
   }
 
   void done() {
     if (p_ != e_)
-      throw xdr_bad_message_size("unmarshaling did not consume whole message");
+      throw_xdr_bad_message_size("unmarshaling did not consume whole message");
   }
 };
 

--- a/xdrpp/rpc_msg.cc
+++ b/xdrpp/rpc_msg.cc
@@ -115,18 +115,18 @@ void
 check_call_hdr(const rpc_msg &hdr)
 {
   if (hdr.body.mtype() != REPLY)
-    throw xdr_runtime_error("call received when reply expected");
+    throw_xdr_runtime_error("call received when reply expected");
   switch (hdr.body.rbody().stat()) {
   case MSG_ACCEPTED:
     if (hdr.body.rbody().areply().reply_data.stat() == SUCCESS)
       return;
-    throw xdr_call_error(hdr.body.rbody().areply().reply_data.stat());
+    throw_xdr_call_error(hdr.body.rbody().areply().reply_data.stat());
   case MSG_DENIED:
     if (hdr.body.rbody().rreply().stat() == AUTH_ERROR)
-      throw xdr_call_error(hdr.body.rbody().rreply().rj_why());
-    throw xdr_call_error(rpc_call_stat::RPCVERS_MISMATCH);
+      throw_xdr_call_error(hdr.body.rbody().rreply().rj_why());
+    throw_xdr_call_error(rpc_call_stat::RPCVERS_MISMATCH);
   default:
-    throw xdr_runtime_error("check_call_hdr: garbage reply_stat");
+    throw_xdr_runtime_error("check_call_hdr: garbage reply_stat");
   }
 }
 

--- a/xdrpp/socket_unix.cc
+++ b/xdrpp/socket_unix.cc
@@ -30,7 +30,7 @@ sock_errmsg()
 void
 throw_sockerr(const char *msg)
 {
-  throw std::system_error(errno, std::system_category(), msg);
+  throw_std_system_error(errno, std::system_category(), msg);
 }
 
 ssize_t
@@ -90,7 +90,7 @@ create_selfpipe(sock_t ss[2])
 {
   int fds[2];
   if (pipe(fds) == -1)
-    throw std::system_error(errno, std::system_category(), "pipe");
+    throw_std_system_error(errno, std::system_category(), "pipe");
   ss[0] = sock_t(fds[0]);
   ss[1] = sock_t(fds[1]);
 }

--- a/xdrpp/srpc.cc
+++ b/xdrpp/srpc.cc
@@ -32,24 +32,24 @@ read_message(sock_t s)
   std::uint32_t len;
   ssize_t n = fullread(s, &len, 4);
   if (n == -1)
-    throw xdr_system_error("xdr::read_message");
+    throw_xdr_system_error("xdr::read_message");
   if (n < 4)
-    throw xdr_bad_message_size("read_message: premature EOF");
+    throw_xdr_bad_message_size("read_message: premature EOF");
   if (len & 3)
-    throw xdr_bad_message_size("read_message: received size not multiple of 4");
+    throw_xdr_bad_message_size("read_message: received size not multiple of 4");
 
   len = swap32le(len);
   if (len & 0x80000000)
     len &= 0x7fffffff;
   else
-    throw xdr_bad_message_size("read_message: message fragments unimplemented");
+    throw_xdr_bad_message_size("read_message: message fragments unimplemented");
 
   msg_ptr m = message_t::alloc(len);
   n = fullread(s, m->data(), len);
   if (n == -1)
-    throw xdr_system_error("xdr::read_message");
+    throw_xdr_system_error("xdr::read_message");
   if (n != len)
-    throw xdr_bad_message_size("read_message: premature EOF");
+    throw_xdr_bad_message_size("read_message: premature EOF");
 
   return m;
 }
@@ -59,7 +59,7 @@ write_message(sock_t s, const msg_ptr &m)
 {
   ssize_t n = write(s, m->raw_data(), m->raw_size());
   if (n == -1)
-    throw xdr_system_error("xdr::write_message");
+    throw_xdr_system_error("xdr::write_message");
   // If this assertion fails, the file descriptor may have had
   // O_NONBLOCK set, which is not allowed for the synchronous
   // interface.

--- a/xdrpp/srpc.h
+++ b/xdrpp/srpc.h
@@ -61,7 +61,7 @@ public:
     archive(g, hdr);
     check_call_hdr(hdr);
     if (hdr.xid != xid)
-      throw xdr_runtime_error("synchronous_client: unexpected xid");
+      throw_xdr_runtime_error("synchronous_client: unexpected xid");
 
     pointer<typename P::res_wire_type> r;
     archive(g, r.activate());

--- a/xdrpp/types.h
+++ b/xdrpp/types.h
@@ -46,32 +46,30 @@ size32(size_t s)
 
 #define THROW_MACRO(expname) \
   template<typename... T> \
-  void throw_##expname (T... what) \
+  [[noreturn]] void throw_##expname (T&&... what) \
   { \
     throw expname (what...); \
   }
  #define THROW_MACRO_STD(expname) \
   template<typename... T> \
-  void throw_std_##expname (T... what) \
+  [[noreturn]] void throw_std_##expname (T&&... what) \
   { \
     throw std:: expname (what...); \
   }
 #else
  #define THROW_MACRO(expname) \
   template<typename... T> \
-  void throw_##expname (T... what) \
+  [[noreturn]] void throw_##expname (T&&... what) \
   { \
     std::abort(); \
   }
  #define THROW_MACRO_STD(expname) \
   template<typename... T> \
-  void throw_std_##expname (T... what) \
+  [[noreturn]] void throw_std_##expname (T&&... what) \
   { \
     std::abort(); \
   }
 #endif
-
-#if __cpp_exceptions
 
 //! Generic class of XDR unmarshaling errors.
 struct xdr_runtime_error : std::runtime_error {
@@ -116,8 +114,6 @@ struct xdr_invariant_failed : xdr_runtime_error {
 struct xdr_wrong_union : std::logic_error {
   using std::logic_error::logic_error;
 };
-
-#endif
 
 THROW_MACRO(xdr_runtime_error)
 THROW_MACRO(xdr_overflow)

--- a/xdrpp/types.h
+++ b/xdrpp/types.h
@@ -45,15 +45,15 @@ size32(size_t s)
 #if __cpp_exceptions
 
 #define THROW_MACRO(expname) \
-  template<typename T> \
-  void throw_##expname (T what) \
+  template<typename... T> \
+  void throw_##expname (T... what) \
   { \
-    throw expname (what); \
+    throw expname (what...); \
   }
 #else
  #define THROW_MACRO(expname) \
-  template<typename T> \
-  void throw_##expname (T what) \
+  template<typename... T> \
+  void throw_##expname (T... what) \
   { \
     std::abort(); \
   }
@@ -105,7 +105,7 @@ struct xdr_bad_alloc : std::bad_alloc
 //! Access out of range when marshalling
 struct xdr_out_of_range : std::out_of_range
 {
-  using std::out_of_range::out_of_range
+  using std::out_of_range::out_of_range;
 };
 
 //! Attempt to access wrong field of a union.  Note that this is not
@@ -869,7 +869,7 @@ inline constexpr R
 with_nth(T &&t, int n, F &&f)
 {
   return with_n<std::tuple_size_v<std::remove_cvref_t<T>>, R>(n, [&](auto i) {
-    return std::forward<F>(f)(get<i>(std::forward<T>(t)));
+    return std::forward<F>(f)(std::get<i>(std::forward<T>(t)));
   });
 }
 

--- a/xdrpp/types.h
+++ b/xdrpp/types.h
@@ -50,10 +50,22 @@ size32(size_t s)
   { \
     throw expname (what...); \
   }
+ #define THROW_MACRO_STD(expname) \
+  template<typename... T> \
+  void throw_std_##expname (T... what) \
+  { \
+    throw std:: expname (what...); \
+  }
 #else
  #define THROW_MACRO(expname) \
   template<typename... T> \
   void throw_##expname (T... what) \
+  { \
+    std::abort(); \
+  }
+ #define THROW_MACRO_STD(expname) \
+  template<typename... T> \
+  void throw_std_##expname (T... what) \
   { \
     std::abort(); \
   }
@@ -96,18 +108,6 @@ struct xdr_invariant_failed : xdr_runtime_error {
   using xdr_runtime_error::xdr_runtime_error;
 };
 
-//! Allocation failed
-struct xdr_bad_alloc : std::bad_alloc
-{
-  using std::bad_alloc::bad_alloc;
-};
-
-//! Access out of range when marshalling
-struct xdr_out_of_range : std::out_of_range
-{
-  using std::out_of_range::out_of_range;
-};
-
 //! Attempt to access wrong field of a union.  Note that this is not
 //! an \c xdr_runtime_error, because it cannot result from
 //! unmarshalling garbage arguments.  Rather it is a logic error in
@@ -127,10 +127,12 @@ THROW_MACRO(xdr_bad_discriminant)
 THROW_MACRO(xdr_should_be_zero)
 THROW_MACRO(xdr_invariant_failed)
 THROW_MACRO(xdr_wrong_union)
-THROW_MACRO(xdr_bad_alloc)
-THROW_MACRO(xdr_out_of_range)
+THROW_MACRO_STD(bad_alloc)
+THROW_MACRO_STD(out_of_range)
+THROW_MACRO_STD(system_error)
 
 #undef THROW_MACRO
+#undef THROW_MACRO_STD
 
 ////////////////////////////////////////////////////////////////
 // Templates for XDR traversal and processing

--- a/xdrpp/types.h
+++ b/xdrpp/types.h
@@ -96,6 +96,18 @@ struct xdr_invariant_failed : xdr_runtime_error {
   using xdr_runtime_error::xdr_runtime_error;
 };
 
+//! Allocation failed
+struct xdr_bad_alloc : std::bad_alloc
+{
+  using std::bad_alloc::bad_alloc;
+};
+
+//! Access out of range when marshalling
+struct xdr_out_of_range : std::out_of_range
+{
+  using std::out_of_range::out_of_range
+};
+
 //! Attempt to access wrong field of a union.  Note that this is not
 //! an \c xdr_runtime_error, because it cannot result from
 //! unmarshalling garbage arguments.  Rather it is a logic error in
@@ -115,6 +127,8 @@ THROW_MACRO(xdr_bad_discriminant)
 THROW_MACRO(xdr_should_be_zero)
 THROW_MACRO(xdr_invariant_failed)
 THROW_MACRO(xdr_wrong_union)
+THROW_MACRO(xdr_bad_alloc)
+THROW_MACRO(xdr_out_of_range)
 
 #undef THROW_MACRO
 


### PR DESCRIPTION
Add enough support to build xdrpp with -fno-exceptions to use the marshalling and generated xdr headers.  Not a full implementation of the networking library with -fno-exceptions.

It'd be useful to build xdrpp into two libraries (one for network stack, one for marshaling) and to add separate compile flags for each.