### PR TITLE
Bump to C++20

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -26,7 +26,7 @@ AC_CHECK_PROGS(YACC, 'bison -y', bison -y)
 AC_PROG_CC
 AM_PROG_CC_C_O
 AC_PROG_CXX([clang++ eg++ g++ c++ gpp aCC CC cxx cc++ cl.exe FCC KCC RCC xlC_r xlC])
-AX_CXX_COMPILE_STDCXX(14,,mandatory)
+AX_CXX_COMPILE_STDCXX(20,,mandatory)
 test -z "$WFLAGS" || CXXFLAGS="$CXXFLAGS $WFLAGS"
 AC_LANG(C++)
 # -pthread Seems to be required by g++ -stc=c++1[14]

--- a/m4/ax_cxx_compile_stdcxx.m4
+++ b/m4/ax_cxx_compile_stdcxx.m4
@@ -10,13 +10,13 @@
 #
 #   Check for baseline language coverage in the compiler for the specified
 #   version of the C++ standard.  If necessary, add switches to CXX and
-#   CXXCPP to enable support.  VERSION may be '11' (for the C++11 standard)
-#   or '14' (for the C++14 standard).
+#   CXXCPP to enable support.  VERSION may be '11', '14', '17', '20', or
+#   '23' for the respective C++ standard version.
 #
 #   The second argument, if specified, indicates whether you insist on an
 #   extended mode (e.g. -std=gnu++11) or a strict conformance mode (e.g.
 #   -std=c++11).  If neither is specified, you get whatever works, with
-#   preference for an extended mode.
+#   preference for no added switch, and then for an extended mode.
 #
 #   The third argument, if specified 'mandatory' or if left unspecified,
 #   indicates that baseline support for the specified C++ standard is
@@ -33,23 +33,28 @@
 #   Copyright (c) 2014, 2015 Google Inc.; contributed by Alexey Sokolov <sokolov@google.com>
 #   Copyright (c) 2015 Paul Norman <penorman@mac.com>
 #   Copyright (c) 2015 Moritz Klammler <moritz@klammler.eu>
-#   Copyright (c) 2016 Krzesimir Nowak <qdlacz@gmail.com>
+#   Copyright (c) 2016, 2018 Krzesimir Nowak <qdlacz@gmail.com>
+#   Copyright (c) 2019 Enji Cooper <yaneurabeya@gmail.com>
+#   Copyright (c) 2020 Jason Merrill <jason@redhat.com>
+#   Copyright (c) 2021, 2024 Jörn Heusipp <osmanx@problemloesungsmaschine.de>
+#   Copyright (c) 2015, 2022, 2023, 2024 Olly Betts
 #
 #   Copying and distribution of this file, with or without modification, are
 #   permitted in any medium without royalty provided the copyright notice
 #   and this notice are preserved.  This file is offered as-is, without any
 #   warranty.
 
-#serial 7
+#serial 25
 
 dnl  This macro is based on the code from the AX_CXX_COMPILE_STDCXX_11 macro
 dnl  (serial version number 13).
 
-AX_REQUIRE_DEFINED([AC_MSG_WARN])
 AC_DEFUN([AX_CXX_COMPILE_STDCXX], [dnl
   m4_if([$1], [11], [ax_cxx_compile_alternatives="11 0x"],
         [$1], [14], [ax_cxx_compile_alternatives="14 1y"],
         [$1], [17], [ax_cxx_compile_alternatives="17 1z"],
+        [$1], [20], [ax_cxx_compile_alternatives="20"],
+        [$1], [23], [ax_cxx_compile_alternatives="23"],
         [m4_fatal([invalid first argument `$1' to AX_CXX_COMPILE_STDCXX])])dnl
   m4_if([$2], [], [],
         [$2], [ext], [],
@@ -61,14 +66,16 @@ AC_DEFUN([AX_CXX_COMPILE_STDCXX], [dnl
         [m4_fatal([invalid third argument `$3' to AX_CXX_COMPILE_STDCXX])])
   AC_LANG_PUSH([C++])dnl
   ac_success=no
-  AC_CACHE_CHECK(whether $CXX supports C++$1 features by default,
-  ax_cv_cxx_compile_cxx$1,
-  [AC_COMPILE_IFELSE([AC_LANG_SOURCE([_AX_CXX_COMPILE_STDCXX_testbody_$1])],
-    [ax_cv_cxx_compile_cxx$1=yes],
-    [ax_cv_cxx_compile_cxx$1=no])])
-  if test x$ax_cv_cxx_compile_cxx$1 = xyes; then
-    ac_success=yes
-  fi
+
+  m4_if([$2], [], [dnl
+    AC_CACHE_CHECK(whether $CXX supports C++$1 features by default,
+		   ax_cv_cxx_compile_cxx$1,
+      [AC_COMPILE_IFELSE([AC_LANG_SOURCE([_AX_CXX_COMPILE_STDCXX_testbody_$1])],
+        [ax_cv_cxx_compile_cxx$1=yes],
+        [ax_cv_cxx_compile_cxx$1=no])])
+    if test x$ax_cv_cxx_compile_cxx$1 = xyes; then
+      ac_success=yes
+    fi])
 
   m4_if([$2], [noext], [], [dnl
   if test x$ac_success = xno; then
@@ -99,9 +106,18 @@ AC_DEFUN([AX_CXX_COMPILE_STDCXX], [dnl
     dnl HP's aCC needs +std=c++11 according to:
     dnl http://h21007.www2.hp.com/portal/download/files/unprot/aCxx/PDF_Release_Notes/769149-001.pdf
     dnl Cray's crayCC needs "-h std=c++11"
+    dnl MSVC needs -std:c++NN for C++17 and later (default is C++14)
     for alternative in ${ax_cxx_compile_alternatives}; do
-      for switch in -std=c++${alternative} +std=c++${alternative} "-h std=c++${alternative}"; do
-        cachevar=AS_TR_SH([ax_cv_cxx_compile_cxx$1_$switch])
+      for switch in -std=c++${alternative} +std=c++${alternative} "-h std=c++${alternative}" MSVC; do
+        if test x"$switch" = xMSVC; then
+          dnl AS_TR_SH maps both `:` and `=` to `_` so -std:c++17 would collide
+          dnl with -std=c++17.  We suffix the cache variable name with _MSVC to
+          dnl avoid this.
+          switch=-std:c++${alternative}
+          cachevar=AS_TR_SH([ax_cv_cxx_compile_cxx$1_${switch}_MSVC])
+        else
+          cachevar=AS_TR_SH([ax_cv_cxx_compile_cxx$1_$switch])
+        fi
         AC_CACHE_CHECK(whether $CXX supports C++$1 features with $switch,
                        $cachevar,
           [ac_save_CXX="$CXX"
@@ -139,29 +155,49 @@ AC_DEFUN([AX_CXX_COMPILE_STDCXX], [dnl
               [define if the compiler supports basic C++$1 syntax])
   fi
   AC_SUBST(HAVE_CXX$1)
-  m4_if([$1], [17], [AC_MSG_WARN([C++17 is not yet standardized, so the checks may change in incompatible ways anytime])])
 ])
 
 
 dnl  Test body for checking C++11 support
 
 m4_define([_AX_CXX_COMPILE_STDCXX_testbody_11],
-  _AX_CXX_COMPILE_STDCXX_testbody_new_in_11
+  [_AX_CXX_COMPILE_STDCXX_testbody_new_in_11]
 )
-
 
 dnl  Test body for checking C++14 support
 
 m4_define([_AX_CXX_COMPILE_STDCXX_testbody_14],
-  _AX_CXX_COMPILE_STDCXX_testbody_new_in_11
-  _AX_CXX_COMPILE_STDCXX_testbody_new_in_14
+  [_AX_CXX_COMPILE_STDCXX_testbody_new_in_11
+   _AX_CXX_COMPILE_STDCXX_testbody_new_in_14]
 )
 
+dnl  Test body for checking C++17 support
+
 m4_define([_AX_CXX_COMPILE_STDCXX_testbody_17],
-  _AX_CXX_COMPILE_STDCXX_testbody_new_in_11
-  _AX_CXX_COMPILE_STDCXX_testbody_new_in_14
-  _AX_CXX_COMPILE_STDCXX_testbody_new_in_17
+  [_AX_CXX_COMPILE_STDCXX_testbody_new_in_11
+   _AX_CXX_COMPILE_STDCXX_testbody_new_in_14
+   _AX_CXX_COMPILE_STDCXX_testbody_new_in_17]
 )
+
+dnl  Test body for checking C++20 support
+
+m4_define([_AX_CXX_COMPILE_STDCXX_testbody_20],
+  [_AX_CXX_COMPILE_STDCXX_testbody_new_in_11
+   _AX_CXX_COMPILE_STDCXX_testbody_new_in_14
+   _AX_CXX_COMPILE_STDCXX_testbody_new_in_17
+   _AX_CXX_COMPILE_STDCXX_testbody_new_in_20]
+)
+
+dnl  Test body for checking C++23 support
+
+m4_define([_AX_CXX_COMPILE_STDCXX_testbody_23],
+  [_AX_CXX_COMPILE_STDCXX_testbody_new_in_11
+   _AX_CXX_COMPILE_STDCXX_testbody_new_in_14
+   _AX_CXX_COMPILE_STDCXX_testbody_new_in_17
+   _AX_CXX_COMPILE_STDCXX_testbody_new_in_20
+   _AX_CXX_COMPILE_STDCXX_testbody_new_in_23]
+)
+
 
 dnl  Tests for new features in C++11
 
@@ -174,7 +210,21 @@ m4_define([_AX_CXX_COMPILE_STDCXX_testbody_new_in_11], [[
 
 #error "This is not a C++ compiler"
 
-#elif __cplusplus < 201103L
+// MSVC always sets __cplusplus to 199711L in older versions; newer versions
+// only set it correctly if /Zc:__cplusplus is specified as well as a
+// /std:c++NN switch:
+//
+// https://devblogs.microsoft.com/cppblog/msvc-now-correctly-reports-__cplusplus/
+//
+// The value __cplusplus ought to have is available in _MSVC_LANG since
+// Visual Studio 2015 Update 3:
+//
+// https://learn.microsoft.com/en-us/cpp/preprocessor/predefined-macros
+//
+// This was also the first MSVC version to support C++14 so we can't use the
+// value of either __cplusplus or _MSVC_LANG to quickly rule out MSVC having
+// C++11 or C++14 support, but we can check _MSVC_LANG for C++17 and later.
+#elif __cplusplus < 201103L && !defined _MSC_VER
 
 #error "This is not a C++11 compiler"
 
@@ -199,11 +249,13 @@ namespace cxx11
 
     struct Base
     {
+      virtual ~Base() {}
       virtual void f() {}
     };
 
     struct Derived : public Base
     {
+      virtual ~Derived() override {}
       virtual void f() override {}
     };
 
@@ -463,7 +515,7 @@ m4_define([_AX_CXX_COMPILE_STDCXX_testbody_new_in_14], [[
 
 #error "This is not a C++ compiler"
 
-#elif __cplusplus < 201402L
+#elif __cplusplus < 201402L && !defined _MSC_VER
 
 #error "This is not a C++14 compiler"
 
@@ -587,19 +639,11 @@ m4_define([_AX_CXX_COMPILE_STDCXX_testbody_new_in_17], [[
 
 #error "This is not a C++ compiler"
 
-#elif __cplusplus <= 201402L
+#elif (defined _MSVC_LANG ? _MSVC_LANG : __cplusplus) < 201703L
 
 #error "This is not a C++17 compiler"
 
 #else
-
-#if defined(__clang__)
-  #define REALLY_CLANG
-#else
-  #if defined(__GNUC__)
-    #define REALLY_GCC
-  #endif
-#endif
 
 #include <initializer_list>
 #include <utility>
@@ -608,16 +652,12 @@ m4_define([_AX_CXX_COMPILE_STDCXX_testbody_new_in_17], [[
 namespace cxx17
 {
 
-#if !defined(REALLY_CLANG)
   namespace test_constexpr_lambdas
   {
-
-    // TODO: test it with clang++ from git
 
     constexpr int foo = [](){return 42;}();
 
   }
-#endif // !defined(REALLY_CLANG)
 
   namespace test::nested_namespace::definitions
   {
@@ -852,11 +892,8 @@ namespace cxx17
 
   }
 
-#if !defined(REALLY_CLANG)
   namespace test_template_argument_deduction_for_class_templates
   {
-
-    // TODO: test it with clang++ from git
 
     template <typename T1, typename T2>
     struct pair
@@ -876,7 +913,6 @@ namespace cxx17
     }
 
   }
-#endif // !defined(REALLY_CLANG)
 
   namespace test_non_type_auto_template_parameters
   {
@@ -890,11 +926,8 @@ namespace cxx17
 
   }
 
-#if !defined(REALLY_CLANG)
   namespace test_structured_bindings
   {
-
-    // TODO: test it with clang++ from git
 
     int arr[2] = { 1, 2 };
     std::pair<int, int> pr = { 1, 2 };
@@ -927,13 +960,9 @@ namespace cxx17
     const auto [ x3, y3 ] = f3();
 
   }
-#endif // !defined(REALLY_CLANG)
 
-#if !defined(REALLY_CLANG)
   namespace test_exception_spec_type_system
   {
-
-    // TODO: test it with clang++ from git
 
     struct Good {};
     struct Bad {};
@@ -952,7 +981,6 @@ namespace cxx17
     static_assert (std::is_same_v<Good, decltype(f(g1, g2))>);
 
   }
-#endif // !defined(REALLY_CLANG)
 
   namespace test_inline_variables
   {
@@ -977,6 +1005,66 @@ namespace cxx17
 
 }  // namespace cxx17
 
-#endif  // __cplusplus <= 201402L
+#endif  // (defined _MSVC_LANG ? _MSVC_LANG : __cplusplus) < 201703L
+
+]])
+
+
+dnl  Tests for new features in C++20
+
+m4_define([_AX_CXX_COMPILE_STDCXX_testbody_new_in_20], [[
+
+#ifndef __cplusplus
+
+#error "This is not a C++ compiler"
+
+#elif (defined _MSVC_LANG ? _MSVC_LANG : __cplusplus) < 202002L
+
+#error "This is not a C++20 compiler"
+
+#else
+
+#include <version>
+
+namespace cxx20
+{
+
+// As C++20 supports feature test macros in the standard, there is no
+// immediate need to actually test for feature availability on the
+// Autoconf side.
+
+}  // namespace cxx20
+
+#endif  // (defined _MSVC_LANG ? _MSVC_LANG : __cplusplus) < 202002L
+
+]])
+
+
+dnl  Tests for new features in C++23
+
+m4_define([_AX_CXX_COMPILE_STDCXX_testbody_new_in_23], [[
+
+#ifndef __cplusplus
+
+#error "This is not a C++ compiler"
+
+#elif (defined _MSVC_LANG ? _MSVC_LANG : __cplusplus) < 202302L
+
+#error "This is not a C++23 compiler"
+
+#else
+
+#include <version>
+
+namespace cxx23
+{
+
+// As C++23 supports feature test macros in the standard, there is no
+// immediate need to actually test for feature availability on the
+// Autoconf side.
+
+}  // namespace cxx23
+
+#endif  // (defined _MSVC_LANG ? _MSVC_LANG : __cplusplus) < 202302L
 
 ]])

--- a/tests/xdrtest.x
+++ b/tests/xdrtest.x
@@ -1,5 +1,5 @@
 %using xdr::operator==;
-%using xdr::operator<;
+%using xdr::operator<=>;
 
 enum senum {
   SE_NEGATIVE = -1,
@@ -65,7 +65,7 @@ union uptr switch (bool b) {
 
 namespace testns {
 %using xdr::operator==;
-%using xdr::operator<;
+%using xdr::operator<=>;
 
 enum other_color {
   RED,

--- a/xdrpp/types.h
+++ b/xdrpp/types.h
@@ -631,20 +631,12 @@ template<typename T> struct pointer : std::unique_ptr<T> {
   friend bool operator==(const pointer &a, const pointer &b) {
     return (!a && !b) || (a && b && *a == *b);
   }
-  friend bool operator!=(const pointer &a, const pointer &b) {
-    return !(a == b);
-  }
-  friend bool operator<(const pointer &a, const pointer &b) {
-    return (!a && b) || (a && b && *a < *b);
-  }
-  friend bool operator>(const pointer &a, const pointer &b) {
-    return b < a;
-  }
-  friend bool operator<=(const pointer &a, const pointer &b) {
-    return !(b < a);
-  }
-  friend bool operator>=(const pointer &a, const pointer &b) {
-    return !(a < b);
+  friend std::partial_ordering operator<=>(const pointer &a, const pointer &b) {
+    if (!a)
+      return !b ? std::strong_ordering::equal : std::strong_ordering::less;
+    if (!b)
+      return std::strong_ordering::greater;
+    return *a <=> *b;
   }
 };
 
@@ -951,7 +943,7 @@ template<typename T> struct struct_equal_helper<T, xdr_struct_base<>> {
   static bool equal(const T &, const T &) { return true; }
 };
 
-template<typename T, typename F> struct struct_lt_helper;
+template<typename T, typename F> struct struct_comp_helper;
 } // namespace detail
 
 
@@ -972,45 +964,13 @@ operator==(const T &a, const T &b)
   return detail::struct_equal_helper<T, xdr_traits<T>>::equal(a, b);
 }
 
-template<typename T> inline typename
-std::enable_if<xdr_traits<T>::is_struct && xdr_traits<T>::xdr_defined,
-	       bool>::type
-operator!=(const T &a, const T &b)
-{
-  return !(a == b);
-}
-
 //! Ordering of XDR structures.  See note at \c xdr::operator==.
 template<typename T> inline typename
 std::enable_if<xdr_traits<T>::is_struct && xdr_traits<T>::xdr_defined,
-	       bool>::type
-operator<(const T &a, const T &b)
+	       std::partial_ordering>::type
+operator<=>(const T &a, const T &b)
 {
-  return detail::struct_lt_helper<T, xdr_traits<T>>::lt(a, b);
-}
-
-template<typename T> inline typename
-std::enable_if<xdr_traits<T>::is_struct && xdr_traits<T>::xdr_defined,
-	       bool>::type
-operator>(const T &a, const T &b)
-{
-  return b < a;
-}
-
-template<typename T> inline typename
-std::enable_if<xdr_traits<T>::is_struct && xdr_traits<T>::xdr_defined,
-	       bool>::type
-operator<=(const T &a, const T &b)
-{
-  return !(b < a);
-}
-
-template<typename T> inline typename
-std::enable_if<xdr_traits<T>::is_struct && xdr_traits<T>::xdr_defined,
-	       bool>::type
-operator>=(const T &a, const T &b)
-{
-  return !(a < b);
+  return detail::struct_comp_helper<T, xdr_traits<T>>::comp(a, b);
 }
 
 namespace detail {
@@ -1023,14 +983,15 @@ struct union_field_equal_t {
 };
 Constexpr const union_field_equal_t union_field_equal {};
 
-struct union_field_lt_t {
-  Constexpr union_field_lt_t() {}
+struct union_field_comp_t {
+  Constexpr union_field_comp_t() {}
   template<typename T, typename F>
-  void operator()(F T::*mp, const T &a, const T &b, bool &out) const {
-    out = a.*mp < b.*mp;
+  void operator()(F T::*mp, const T &a, const T &b,
+      std::partial_ordering &out) const {
+    out = a.*mp <=> b.*mp;
   }
 };
-Constexpr const union_field_lt_t union_field_lt {};
+Constexpr const union_field_comp_t union_field_comp {};
 } // namespace detail
 
 //! Equality of XDR unions.  See note at \c xdr::operator== for XDR
@@ -1050,33 +1011,36 @@ operator==(const T &a, const T &b)
 
 //! Ordering of XDR unions.  See note at \c xdr::operator==.
 template<typename T> inline typename
-std::enable_if<xdr_traits<T>::is_union, bool>::type
-operator<(const T &a, const T &b)
+std::enable_if<xdr_traits<T>::is_union, std::partial_ordering>::type
+operator<=>(const T &a, const T &b)
 {
-  if (a._xdr_discriminant() < b._xdr_discriminant())
-    return true;
-  if (b._xdr_discriminant() < a._xdr_discriminant())
-    return false;
+  if (std::partial_ordering res =
+      a._xdr_discriminant() <=> b._xdr_discriminant();
+      res != std::partial_ordering::equivalent) {
+    return res;
+  }
 
-  bool r{false};
-  a._xdr_with_mem_ptr(detail::union_field_lt,
+  std::partial_ordering r{std::partial_ordering::unordered};
+  a._xdr_with_mem_ptr(detail::union_field_comp,
 		      a._xdr_discriminant(), a, b, r);
   return r;
 }
 
 namespace detail {
-template<typename T, typename F> struct struct_lt_helper {
-  static bool lt(const T &a, const T &b) {
+template<typename T, typename F> struct struct_comp_helper {
+  static std::partial_ordering comp(const T &a, const T &b) {
     Constexpr const typename F::field_info fi {};
-    if ((fi(a) < fi(b)))
-      return true;
-    if ((fi(b) < fi(a)))
-      return false;
-    return struct_lt_helper<T, typename F::next_field>::lt(a, b);
+    if (std::partial_ordering res = fi(a) <=> fi(b);
+        res != std::partial_ordering::equivalent) {
+      return res;
+    }
+    return struct_comp_helper<T, typename F::next_field>::comp(a, b);
   }
 };
-template<typename T> struct struct_lt_helper<T, xdr_struct_base<>> {
-  static bool lt(const T &, const T &) { return false; }
+template<typename T> struct struct_comp_helper<T, xdr_struct_base<>> {
+  static std::partial_ordering comp(const T &, const T &) {
+    return std::partial_ordering::unordered;
+}
 };
 } // namespace detail
 


### PR DESCRIPTION
Bump the version of `m4/ax_cxx_compile_stdcxx.m4` and the version used in the call to `AX_CXX_COMPILE_STDCXX` in `configure.ac`. Also, update the `operator<` calls to be `operator<=>` calls. To produce correct code on C++20, this is necessary for at least `xdr::pointer`s: otherwise, e.g., `std::vector<xdr::pointer<int>>`s will not sort properly.