### PR TITLE
Fix msvc build for C++20

### DIFF
--- a/msvc_xdrpp/xdrc/xdrc.vcxproj
+++ b/msvc_xdrpp/xdrc/xdrc.vcxproj
@@ -102,6 +102,7 @@
       <PreprocessorDefinitions>_MBCS;%(PreprocessorDefinitions);_CRT_SECURE_NO_WARNINGS</PreprocessorDefinitions>
       <RuntimeLibrary>MultiThreadedDebugDLL</RuntimeLibrary>
       <BrowseInformation>false</BrowseInformation>
+      <LanguageStandard>stdcpp20</LanguageStandard>
     </ClCompile>
     <Link>
       <GenerateDebugInformation>true</GenerateDebugInformation>
@@ -131,6 +132,7 @@
       <BrowseInformation>false</BrowseInformation>
       <AdditionalIncludeDirectories>..\..;..\..\xdrc;..\..\compat;..\include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
       <PreprocessorDefinitions>_MBCS;%(PreprocessorDefinitions);_CRT_SECURE_NO_WARNINGS</PreprocessorDefinitions>
+      <LanguageStandard>stdcpp20</LanguageStandard>
     </ClCompile>
     <Link>
       <GenerateDebugInformation>true</GenerateDebugInformation>
@@ -154,10 +156,10 @@
   <ItemGroup>
     <CustomBuild Include="..\..\xdrc\scan.ll">
       <FileType>Document</FileType>
-      <Command Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">flex --nounistd -o ../../xdrc/scan.cc ../../xdrc/scan.ll</Command>
-      <Command Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">flex --nounistd -o ../../xdrc/scan.cc ../../xdrc/scan.ll</Command>
-      <Command Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">flex --nounistd -o ../../xdrc/scan.cc ../../xdrc/scan.ll</Command>
-      <Command Condition="'$(Configuration)|$(Platform)'=='Release|x64'">flex --nounistd -o ../../xdrc/scan.cc ../../xdrc/scan.ll</Command>
+      <Command Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">wsl flex --nounistd -o ../../xdrc/scan.cc ../../xdrc/scan.ll</Command>
+      <Command Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">wsl flex --nounistd -o ../../xdrc/scan.cc ../../xdrc/scan.ll</Command>
+      <Command Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">wsl flex --nounistd -o ../../xdrc/scan.cc ../../xdrc/scan.ll</Command>
+      <Command Condition="'$(Configuration)|$(Platform)'=='Release|x64'">wsl flex --nounistd -o ../../xdrc/scan.cc ../../xdrc/scan.ll</Command>
       <Outputs Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">../../xdrc/scan.cc</Outputs>
       <Outputs Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">../../xdrc/scan.cc</Outputs>
       <Outputs Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">../../xdrc/scan.cc</Outputs>
@@ -175,8 +177,8 @@
   <ItemGroup>
     <CustomBuild Include="..\..\xdrc\parse.yy">
       <FileType>Document</FileType>
-      <Command Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">bison -o ../../xdrc/parse.cc --defines=../../xdrc/parse.hh ../../xdrc/parse.yy</Command>
-      <Command Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">bison -o ../../xdrc/parse.cc --defines=../../xdrc/parse.hh ../../xdrc/parse.yy</Command>
+      <Command Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">wsl bison -o ../../xdrc/parse.cc --defines=../../xdrc/parse.hh ../../xdrc/parse.yy</Command>
+      <Command Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">wsl bison -o ../../xdrc/parse.cc --defines=../../xdrc/parse.hh ../../xdrc/parse.yy</Command>
       <Message Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">Running bison</Message>
       <Message Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">Running bison</Message>
       <Outputs Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">%(RelativeDir)parse.hh;%(RelativeDir)parse.cc</Outputs>
@@ -185,8 +187,8 @@
       <LinkObjects Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">false</LinkObjects>
       <AdditionalInputs Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">%(RelativeDir)parse.yy</AdditionalInputs>
       <AdditionalInputs Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">%(RelativeDir)parse.yy</AdditionalInputs>
-      <Command Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">bison -o ../../xdrc/parse.cc --defines=../../xdrc/parse.hh ../../xdrc/parse.yy</Command>
-      <Command Condition="'$(Configuration)|$(Platform)'=='Release|x64'">bison -o ../../xdrc/parse.cc --defines=../../xdrc/parse.hh ../../xdrc/parse.yy</Command>
+      <Command Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">wsl bison -o ../../xdrc/parse.cc --defines=../../xdrc/parse.hh ../../xdrc/parse.yy</Command>
+      <Command Condition="'$(Configuration)|$(Platform)'=='Release|x64'">wsl bison -o ../../xdrc/parse.cc --defines=../../xdrc/parse.hh ../../xdrc/parse.yy</Command>
       <Message Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">Running bison</Message>
       <Message Condition="'$(Configuration)|$(Platform)'=='Release|x64'">Running bison</Message>
       <Outputs Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">%(RelativeDir)parse.hh;%(RelativeDir)parse.cc</Outputs>

--- a/msvc_xdrpp/xdrpp/xdrpp.vcxproj
+++ b/msvc_xdrpp/xdrpp/xdrpp.vcxproj
@@ -119,6 +119,7 @@
       <AdditionalIncludeDirectories>..\..;..\include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
       <RuntimeLibrary>MultiThreadedDebugDLL</RuntimeLibrary>
       <BrowseInformation>false</BrowseInformation>
+      <LanguageStandard>stdcpp20</LanguageStandard>
     </ClCompile>
     <Link>
       <GenerateDebugInformation>true</GenerateDebugInformation>
@@ -162,6 +163,7 @@
       <SDLCheck>true</SDLCheck>
       <BrowseInformation>false</BrowseInformation>
       <AdditionalIncludeDirectories>..\..;..\include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <LanguageStandard>stdcpp20</LanguageStandard>
     </ClCompile>
     <Link>
       <GenerateDebugInformation>true</GenerateDebugInformation>


### PR DESCRIPTION
This fixes the msvc build stuff to work with the recent shift to C++20

It also inserts `wsl` before invocations of flex and bison, which makes it easier to build on most modern windows installations (which will have wsl2 more often than mingw). We've already done this on stellar-core and I think at this point we're the only ones using xdrpp anyways.