### PR TITLE
run cpp under wsl when building for msvc

### DIFF
--- a/msvc_xdrpp/include/xdrpp/config.h
+++ b/msvc_xdrpp/include/xdrpp/config.h
@@ -1,4 +1,4 @@
-#define CPP_COMMAND "cpp.exe"
+#define CPP_COMMAND "wsl cpp"
 #define PACKAGE "xdrpp"
 #define PACKAGE_NAME "xdrpp"
 #define PACKAGE_VERSION "0"


### PR DESCRIPTION
Another small fix to make xdrc run cpp under wsl when building on windows.